### PR TITLE
Amend and Flag discrepancies in the draft minutes for SGM 2: Electric Boogaloo

### DIFF
--- a/2025/2025-05-08.md
+++ b/2025/2025-05-08.md
@@ -16,7 +16,10 @@ Open positions:
 
 Potentially open positions:  
 - President  
-- Event Officer  
+- Event Officer
+
+#### General Business
+- Special Resolutions
 
 ## Quorum
 24 required. 64 attendees. Quorum met.
@@ -24,7 +27,7 @@ Potentially open positions:
 ## Chair of Meeting
 Motion for Richard to become chair for this meeting – seconded by Iain.  
 Bradley mentions there would be a conflict of interest  because Richie is running for President.  
-Isaac nominates himself to be chair – passes by majority.
+Isaac nominates himself to be chair, seconded by ?? – passes by majority.
 
 Isaac confirms the quorum and reminds attendees about the attendance sheet.
 
@@ -35,11 +38,11 @@ The President offers a high-level overview and addresses the recent concerns.
 
 Points raised regarding the requisition included:
 
-Moving onto the topic of Competitive Programming Club (CPG).
+***Moving onto the topic of Competitive Programming Club (CPG).***
 
 The President addressed the recent controversies regarding the Competitive Programming Group (CPG) and apologised to the wider community for the distress that may have been caused. He states that this was a genuine mistake and apologised for the not communicating this to the committee prior to the announcement.
 
-Moving onto the topic of shadow decision making.
+***Moving onto the topic of shadow decision making.***
 
 The President comments that meetings surrounding the portfolio of Industry and Events were taken place and were in preparation for the sponsor prospectus.
 
@@ -58,7 +61,7 @@ Avery comments on the lack of warning which could be seen as neglectful. Iain sa
 
 The President confirms this was also the case for this year.
 
-Moving onto the topic of neglect of core events.
+***Moving onto the topic of neglect of core events.***
 
 The president notes that the society's finances is not only a concern for the Treasurer but also to the President himself. Together, the President, Secretary and Treasurer brainstormed ways to increase engagement and the topic of student talks araised. The ex-secretary had a great idea for student talks which revolved around coordinating "2 events in one night". The President notes that is a great idea as it would increase attendees while saving money on pizza. 
 
@@ -78,9 +81,9 @@ Bradley comments that, according to the Constitution, T3 has no additional power
 
 Anshul asks if the slides will be made available on the Discord server. The President replies that it depends, some people have asked their messages (within the screenshots) not to be put up within the Discord server. Consent would need to be obtained.
 
-During this discussion, it was announced that President Jackie Chang had resigned. Following this announcement, the meeting was no longer about the requisition, as the grounds for removal were moot.
+Quinn motions to hear the remainder of the president's speech without interruption to speed up the process – seconded by Avery. Motion passed by majority. 
 
-Quinn motions to hear the remainder of the ex-president speech without interruption to speed up the process – seconded by Avery. Motion passed by majority.  
+Prior to the speech resuming, it was announced that President Jackie Chang had resigned. Following this announcement, the meeting was no longer about the requisition, as the grounds for removal were moot.
 
 Quinn suggests the rest of the speech be heard during general business. Isaac makes a procedural motion to move to general business (to occur after elections).  
 
@@ -90,28 +93,27 @@ Bradley asks for a show of hands from those who need to leave by 7 PM (some hand
 
 Isaac retracts all previous motions due to confusion. Motion for 15 uninterrupted minutes for the ex-president to speak (Avery seconded). The motion passes by majority.
 
-Moving onto the topic of discord neglect.
+***Moving onto the topic of discord neglect.***
 
 The ex-president addresses the concerns about deleting Discord - the main method of communication between UQCS committee. He displays the frequency of messages sent during his presidency where multiple discussions and meetings occured. 
 
-Moving onto the topic of SGM delays.
+***Moving onto the topic of SGM delays.***
 
 The ex-president addresses delays in publishing the AGM minutes, showing the times discussed and agreed upon by the committee.
 
-Moving onto the topic of AGM minutes.
+***Moving onto the topic of AGM minutes.***
 
 The ex-president states that for anyone, taking minutes for 4+ hours would be overwhelming. The AGM was recorded to make the process of minuting easier. During a private meeting with the Secretary, this was mentioned and the Secretary was eager to help out and noted they would complete the AGM minutes. The Secretary requested that the minutes to be looked over upon completion. 
 
 Jackie ends off by thanking everyone and apologises to past and current committee and everyone in wider community for the distress he they may have caused. 
 
-Masham motions to order pizza; Richie seconded. Motion passes by majority.  
-Isaac motions to adjourn the meeting; motion passes by majority.
+Masham motions to adjourn for pizza for 15 minutes; Richie seconded. Motion passes by majority.  
 
-Meeting adjourned **7:08 PM**. Meeting resumed at **7:21 PM**.  
+Meeting adjourned **7:06 PM**. Meeting resumed at **7:21 PM**.  
 
 ## Returning Officer
 Isaac motions for Bradley to be Returning Officer (Max seconded).
-Iain motions for president nominee speeches: 2 minutes for the nominated individual, 1 minute for others speaking on their behalf (Majority pass).
+Iain motions for nominee speech time limits: 2 minutes for presidential nominees, 1 minute for other roles (Majority pass).
 Zain asks for clarifications.
 
 Bradley reads out the rules and process for the voting.
@@ -147,16 +149,14 @@ Jesse elected as Secretary.
 ## Vacant Casual Treasurer Position
 Richie expresses interest in filling the vacant casual Treasurer position.
 
-Isaac seconds Bradley's motion for an opinion poll (majority pass).
+Isaac seconds Bradley's motion for an opinion poll to inform committee of the members' desires on how to fill the casual vacancy (majority pass).
 
-Richie nominates Zain for vacant Treasurer. Zain wins the opinion poll.
-
-Zain elected as Vacant Casual Treasurer
+Richie nominates Zain to be considered in the poll. With no other nominations, Zain wins the opinion poll.
 
 ## Events Officer
 Jesse speaks on the role.
 
-Zain withdraws his nomination. Avery nominates Amy, but she declines. Tyrese nominates himself.
+Zain withdraws his nomination. Avery nominates Amy, but she declines. Tyrese nominates himself (?? seconds).
 Tyrese elected as Events Officer.
 
 ## Media Officer
@@ -176,13 +176,13 @@ Najma starts speech (8:15 PM - 8:16 PM)
 Naveed elected as Media Officer.
 
 ## General Committee
-Cyrus nominates himself.
-Anshul nominates himself.
+Cyrus nominates himself (?? seconds).
+Anshul nominates himself (?? seconds).
 
 General committee speeches begin.
 Zain resigns from the general committee.
 Iain motions to create a 4th general committee position (Iain seconded) - passed by majority.
-Cielo nominates himself.
+Cielo nominates himself (?? seconds).
 
 April starts speech (8:26 PM - 8:26 PM)
 Ryan starts speech and ends (8:26 PM - 8:26 PM)
@@ -196,10 +196,10 @@ Motion to continue with general business while votes are being counted. Someone 
 
 General committee elected (during general business): Anshul, April, Chris, Cielo.
 
-## General Business (Constitutional amendments):
+## General Business (Special Resolutions):
 Constitutional Amendment PR #61 (Pizza clause): Iain motions to table it until the next GM. Someone seconded. Motion passes by majority.
 
-*69 BALLOTS!!!!!!!!!!*
+Bradley observes that for the election of General Committee, attendees had collectively cast *69 BALLOTS!!!!!!!!!!*
 
 - Constitutional Amendment PR #57:
 
@@ -209,7 +209,7 @@ Alex motions to vote on this amendment. Someone seconded. Passes by majority.
 
 - Constitutional Amendment PR #51, withdrew.
 
-- Constitutional Amendment PR #65: Quinn speaks on Bradley's contributions.
+- Life Membership PR #65: Quinn speaks on Bradley's contributions.
 
 Krit motions to vote on this. Someone seconded. Passes by majority.
 

--- a/2025/2025-05-08.md
+++ b/2025/2025-05-08.md
@@ -31,6 +31,8 @@ Isaac nominates himself to be chair, seconded by ?? – passes by majority.
 
 Isaac confirms the quorum and reminds attendees about the attendance sheet.
 
+Bradley highlights and the chair notes Jay Hunter's apology "for being unable to attend as I will be receiving a facial at the time of the SGM".
+
 ## Requisition
 The meeting began with the agenda item to address the requisition.
 


### PR DESCRIPTION
In reading through the minutes from the SGM, there are a number of small discrepancies that I've noticed as compared to my recollection of the meeting. These include:
- Misrepresenting that Zain was elected to treasurer (due to notice, the actual appointment needed to be officially made by the committee after the SGM)
- Incorrect ordering of events
- Poorly conveyed motions
- Missing seconders in motions (and while not flagged, seconders have been attributed to `Somebody`)
- Minor wording / style changes for easier review (not important)

This is not a commentary on the minute-taker, but merely an act to flag these for review by committee prior to confirmation of these minutes at the 2025 AGM, and would appreciate / recommend any findings on this be documented in the discussion of this PR for quicker / smoother discussion at the AGM.

I also recognise that some of my corrections could be wrong, and am happy to be corrected if any of this is made in error.